### PR TITLE
Demonstrate polymorphic behavior in CUDA

### DIFF
--- a/src/boundaries.h
+++ b/src/boundaries.h
@@ -1,0 +1,124 @@
+class BoundaryCheckStrategy {
+public:
+    __device__
+    virtual bool check() const = 0;
+
+    __device__
+    virtual dim3 pos() const = 0;
+
+    __device__
+    virtual dim3 dims() const = 0;
+};
+
+/**
+ * A linear check strategy that checks if the current index is within the bounds of a given size
+ * along a one-dimensional array.
+ */
+class LinearCheckStragegy: public BoundaryCheckStrategy {
+ public:
+    __host__
+    explicit LinearCheckStragegy(int len): size_{len} {}
+    
+    __device__
+    bool check() const override {
+        return (pos().x < size_);
+    }
+
+    __device__
+    dim3 pos() const override {
+        return dim3{ blockIdx.x * blockDim.x + threadIdx.x, 0, 0 };
+    }
+
+    __device__
+    dim3 dims() const override{
+        return dim3{ size_, 0, 0 };
+    }
+
+ private:
+    int size_;
+};
+
+class RectangularCheckStrategy: public BoundaryCheckStrategy {
+ public:
+    __host__
+    RectangularCheckStrategy(int m, int n): rows_{m}, cols_{n} {}
+
+    __device__
+    bool check() const override {
+        auto p = pos();
+        return (p.y < rows_ && p.x < cols_);
+    }
+
+    __device__
+    dim3 pos() const override {
+        return dim3 {(blockIdx.x * blockDim.x + threadIdx.x),
+               (blockIdx.y * blockDim.y + threadIdx.y),
+               0 };
+    }
+
+    __device__
+    dim3 dims() const override {
+        return dim3 { cols_, rows_, 0 };
+    }
+
+ private:
+    int rows_;
+    int cols_;
+};
+
+class CubeCheckStrategy: public BoundaryCheckStrategy {
+ public:
+    __host__
+    CubeCheckStrategy(int rows, int cols, int depth): size_{ cols, rows, depth } {}
+
+    __device__
+    bool check() const override {
+        auto curPos = pos();
+        return (curPos.x < size_.x && curPos.y < size_.y && curPos.z < size_.z);
+    }
+
+    __device__
+    dim3 pos() const override {
+        return {
+            (blockIdx.x * blockDim.x + threadIdx.x),
+            (blockIdx.y * blockDim.y + threadIdx.y),
+            (blockIdx.z * blockDim.z + threadIdx.z) };
+    }
+
+    __device__
+    dim3 dims() const override {
+        return size_;
+    }
+
+ private:
+    dim3 size_;
+};
+
+
+class SizeCheck {
+ public:
+    __device__
+    explicit SizeCheck(const BoundaryCheckStrategy* strategy): 
+        strategy_{ strategy } {}
+
+    __device__
+    bool operator()() const {
+        return strategy_->check();
+    }
+
+    __device__
+    int idx() const {
+        auto pos = strategy_->pos();
+        auto dims = strategy_->dims();
+        printf("pos: %d, %d, %d\n", pos.x , pos.y , pos.z);
+        auto matSize = dims.x * dims.y;
+        int idx = pos.z * matSize + 
+                  pos.y * dims.y + 
+                  pos.x;
+
+        return idx;
+    }
+
+ private:
+    const BoundaryCheckStrategy* strategy_;
+};

--- a/src/boundaries.h
+++ b/src/boundaries.h
@@ -1,124 +1,120 @@
-class BoundaryCheckStrategy {
-public:
-    __device__
-    virtual bool check() const = 0;
-
-    __device__
-    virtual dim3 pos() const = 0;
-
-    __device__
-    virtual dim3 dims() const = 0;
-};
+#include <assert.h>
 
 /**
- * A linear check strategy that checks if the current index is within the bounds of a given size
- * along a one-dimensional array.
+ * A linear check strategy that checks if the current index is within the bounds
+ * of a given size along a one-dimensional array.
  */
-class LinearCheckStragegy: public BoundaryCheckStrategy {
+class LinearCheckStragegy {
  public:
-    __host__
-    explicit LinearCheckStragegy(int len): size_{len} {}
-    
-    __device__
-    bool check() const override {
-        return (pos().x < size_);
-    }
+  __host__ explicit LinearCheckStragegy(int len) : size_{len} {}
 
-    __device__
-    dim3 pos() const override {
-        return dim3{ blockIdx.x * blockDim.x + threadIdx.x, 0, 0 };
-    }
+  __device__ bool check() const { return (pos().x < size_); }
 
-    __device__
-    dim3 dims() const override{
-        return dim3{ size_, 0, 0 };
-    }
+  __device__ dim3 pos() const {
+    return dim3{blockIdx.x * blockDim.x + threadIdx.x, 0, 0};
+  }
+
+  __device__ dim3 dims() const { return dim3{size_, 0, 0}; }
 
  private:
-    int size_;
+  int size_;
 };
 
-class RectangularCheckStrategy: public BoundaryCheckStrategy {
+class RectangularCheckStrategy {
  public:
-    __host__
-    RectangularCheckStrategy(int m, int n): rows_{m}, cols_{n} {}
+  __host__ RectangularCheckStrategy(uint m, uint n) : rows_{m}, cols_{n} {}
 
-    __device__
-    bool check() const override {
-        auto p = pos();
-        return (p.y < rows_ && p.x < cols_);
-    }
+  __device__ bool check() const {
+    auto p = pos();
+    return (p.y < rows_ && p.x < cols_);
+  }
 
-    __device__
-    dim3 pos() const override {
-        return dim3 {(blockIdx.x * blockDim.x + threadIdx.x),
-               (blockIdx.y * blockDim.y + threadIdx.y),
-               0 };
-    }
+  __device__ dim3 pos() const {
+    return dim3{(blockIdx.x * blockDim.x + threadIdx.x),
+                (blockIdx.y * blockDim.y + threadIdx.y), 0};
+  }
 
-    __device__
-    dim3 dims() const override {
-        return dim3 { cols_, rows_, 0 };
-    }
+  __device__ dim3 dims() const { return dim3{cols_, rows_, 0}; }
 
  private:
-    int rows_;
-    int cols_;
+  uint rows_;
+  uint cols_;
 };
 
-class CubeCheckStrategy: public BoundaryCheckStrategy {
+class CubeCheckStrategy {
  public:
-    __host__
-    CubeCheckStrategy(int rows, int cols, int depth): size_{ cols, rows, depth } {}
+  __host__ CubeCheckStrategy(uint rows, uint cols, uint depth)
+      : size_{cols, rows, depth} {}
 
-    __device__
-    bool check() const override {
-        auto curPos = pos();
-        return (curPos.x < size_.x && curPos.y < size_.y && curPos.z < size_.z);
-    }
+  __device__ bool check() const {
+    auto curPos = pos();
+    return (curPos.x < size_.x && curPos.y < size_.y && curPos.z < size_.z);
+  }
 
-    __device__
-    dim3 pos() const override {
-        return {
-            (blockIdx.x * blockDim.x + threadIdx.x),
+  __device__ dim3 pos() const {
+    return {(blockIdx.x * blockDim.x + threadIdx.x),
             (blockIdx.y * blockDim.y + threadIdx.y),
-            (blockIdx.z * blockDim.z + threadIdx.z) };
-    }
+            (blockIdx.z * blockDim.z + threadIdx.z)};
+  }
 
-    __device__
-    dim3 dims() const override {
-        return size_;
-    }
+  __device__ dim3 dims() const { return size_; }
 
  private:
-    dim3 size_;
+  dim3 size_;
 };
 
+enum class BoundaryType { Linear, Rectangular, Cube };
 
 class SizeCheck {
  public:
-    __device__
-    explicit SizeCheck(const BoundaryCheckStrategy* strategy): 
-        strategy_{ strategy } {}
-
-    __device__
-    bool operator()() const {
-        return strategy_->check();
+  __device__ explicit SizeCheck(const void *strategy, BoundaryType type) {
+    switch (type) {
+      case BoundaryType::Linear:
+        linStrategy_ = static_cast<const LinearCheckStragegy *>(strategy);
+        assert(linStrategy_ != nullptr);
+        break;
+      case BoundaryType::Rectangular:
+        rectStrategy_ = static_cast<const RectangularCheckStrategy *>(strategy);
+        assert(rectStrategy_ != nullptr);
+        break;
+      case BoundaryType::Cube:
+        cubeStrategy_ = static_cast<const CubeCheckStrategy *>(strategy);
+        assert(cubeStrategy_ != nullptr);
+        break;
     }
+  }
 
-    __device__
-    int idx() const {
-        auto pos = strategy_->pos();
-        auto dims = strategy_->dims();
-        printf("pos: %d, %d, %d\n", pos.x , pos.y , pos.z);
-        auto matSize = dims.x * dims.y;
-        int idx = pos.z * matSize + 
-                  pos.y * dims.y + 
-                  pos.x;
-
-        return idx;
+  __device__ bool operator()() const {
+    if (linStrategy_) {
+      return linStrategy_->check();
+    } else if (rectStrategy_) {
+      return rectStrategy_->check();
+    } else if (cubeStrategy_) {
+      return cubeStrategy_->check();
     }
+    assert(false);
+    return false;  // Should never reach here
+  }
+
+  __device__ int idx() const {
+    assert(linStrategy_ || rectStrategy_ || cubeStrategy_);
+    dim3 pos, dims;
+    if (linStrategy_) {
+      pos = linStrategy_->pos();
+      dims = linStrategy_->dims();
+    } else if (rectStrategy_) {
+      pos = rectStrategy_->pos();
+      dims = rectStrategy_->dims();
+    } else if (cubeStrategy_) {
+      pos = cubeStrategy_->pos();
+      dims = cubeStrategy_->dims();
+    }
+    auto matSize = dims.x * dims.y;
+    return pos.z * matSize + pos.y * dims.x + pos.x;
+  }
 
  private:
-    const BoundaryCheckStrategy* strategy_;
+  const LinearCheckStragegy *linStrategy_ = nullptr;
+  const RectangularCheckStrategy *rectStrategy_ = nullptr;
+  const CubeCheckStrategy *cubeStrategy_ = nullptr;
 };

--- a/src/mat_gen.cu
+++ b/src/mat_gen.cu
@@ -5,154 +5,16 @@
 //
 // Author: Marco Massenzio (marco@alertavert.com)
 
-#include <iostream>
-
 #include <cuda_runtime.h>
 #include <curand.h>
 #include <curand_kernel.h>
 #include <iostream>
 #include <memory>
 
-using namespace std;
-
-class BoundaryCheckStrategy {
-public:
-    __device__
-    virtual bool check() const = 0;
-
-    __device__
-    virtual dim3 pos() const = 0;
-
-    __device__
-    virtual dim3 dims() const = 0;
-};
-
-/**
- * A linear check strategy that checks if the current index is within the bounds of a given size
- * along a one-dimensional array.
- */
-class LinearCheckStragegy: public BoundaryCheckStrategy {
- public:
-    __host__
-    explicit LinearCheckStragegy(int len): size_{len} {}
-    
-    __device__
-    bool check() const override {
-        return (pos().x < size_);
-    }
-
-    __device__
-    dim3 pos() const override {
-        return dim3{ blockIdx.x * blockDim.x + threadIdx.x, 0, 0 };
-    }
-
-    __device__
-    dim3 dims() const override{
-        return dim3{ size_, 0, 0 };
-    }
-
- private:
-    int size_;
-};
-
-class RectangularCheckStrategy: public BoundaryCheckStrategy {
- public:
-    __host__
-    RectangularCheckStrategy(int m, int n): rows_{m}, cols_{n} {}
-
-    __device__
-    bool check() const override {
-        auto p = pos();
-        return (p.y < rows_ && p.x < cols_);
-    }
-
-    __device__
-    dim3 pos() const override {
-        return dim3 {(blockIdx.x * blockDim.x + threadIdx.x),
-               (blockIdx.y * blockDim.y + threadIdx.y),
-               0 };
-    }
-
-    __device__
-    dim3 dims() const override {
-        return dim3 { cols_, rows_, 0 };
-    }
-
- private:
-    int rows_;
-    int cols_;
-};
-
-class CubeCheckStrategy: public BoundaryCheckStrategy {
- public:
-    __host__
-    CubeCheckStrategy(int rows, int cols, int depth): size_{ cols, rows, depth } {}
-
-    __device__
-    bool check() const override {
-        auto curPos = pos();
-        return (curPos.x < size_.x && curPos.y < size_.y && curPos.z < size_.z);
-    }
-
-    __device__
-    dim3 pos() const override {
-        return {
-            (blockIdx.x * blockDim.x + threadIdx.x),
-            (blockIdx.y * blockDim.y + threadIdx.y),
-            (blockIdx.z * blockDim.z + threadIdx.z) };
-    }
-
-    __device__
-    dim3 dims() const override {
-        return size_;
-    }
-
- private:
-    dim3 size_;
-};
-
-
-class SizeCheck {
- public:
-    __device__
-    explicit SizeCheck(const BoundaryCheckStrategy* strategy): 
-        strategy_{ strategy } {}
-
-    __device__
-    bool operator()() const {
-        return strategy_->check();
-    }
-
-    __device__
-    int idx() const {
-        auto pos = strategy_->pos();
-        auto dims = strategy_->dims();
-        printf("pos: %d, %d, %d\n", pos.x , pos.y , pos.z);
-        auto matSize = dims.x * dims.y;
-        int idx = pos.z * matSize + 
-                  pos.y * dims.y + 
-                  pos.x;
-
-        return idx;
-    }
-
- private:
-    const BoundaryCheckStrategy* strategy_;
-};
-
-struct something {
-    int a;
-    int b;
-};
+#include "boundaries.h"
 
 __global__ 
-void fillMatrixKernel(float* mat, something* s, BoundaryCheckStrategy* strategy, float mean, float stddev, unsigned long seed) {
-    printf("threadIdx: %d, %d, %d\n", threadIdx.x, threadIdx.y, threadIdx.z);
-    printf("something: %d, %d\n", s->a, s->b);
-
-    dim3 dims = strategy->dims();
-    printf("dims: %d, %d, %d\n", dims.x, dims.y, dims.z);
-    printf(">>>>>");
+void fillMatrixKernel(float* mat, BoundaryCheckStrategy* strategy, float mean, float stddev, unsigned long seed) {
 
     SizeCheck checker { strategy };
     auto idx = checker.idx();
@@ -165,6 +27,7 @@ void fillMatrixKernel(float* mat, something* s, BoundaryCheckStrategy* strategy,
 }
 
 
+using namespace std;
 
 void fill(float* mat, int m, int n, float mean = 0.0f, float stddev = 1.0f) {
     float* d_mat;
@@ -199,15 +62,9 @@ void fill(float* mat, int m, int n, float mean = 0.0f, float stddev = 1.0f) {
         return;
     }
 
-    something s { 42, 84 };
-    something* d_s;
-    cudaMalloc(&d_s, sizeof(something));
-    cudaMemcpy(d_s, &s, sizeof(something), cudaMemcpyHostToDevice);
-
     // Launch kernel
     fillMatrixKernel<<<gridDim, blockDim>>>(
         d_mat, 
-        d_s,
         d_strategy,
         mean, 
         stddev, 

--- a/src/mat_gen.cu
+++ b/src/mat_gen.cu
@@ -14,12 +14,15 @@
 #include "boundaries.h"
 
 __global__ 
-void fillMatrixKernel(float* mat, BoundaryCheckStrategy* strategy, float mean, float stddev, unsigned long seed) {
+void fillMatrixKernel(float* mat, void* strategy, float mean, float stddev, unsigned long seed) {
 
-    SizeCheck checker { strategy };
-    auto idx = checker.idx();
-    printf("Filling index: %d\n", idx);
+    // Here we lose the flexibility of polymorphic behavior,
+    // as we need to know in advance the type of strategy.
+    // However, in kernel functions, we must know in advance the
+    // arrangement of data.
+    SizeCheck checker { strategy, BoundaryType::Rectangular };
     if (checker()) {
+        auto idx = checker.idx();
         curandState state;
         curand_init(seed, idx, 0, &state);
         mat[idx] = curand_normal(&state) * stddev + mean;
@@ -29,7 +32,7 @@ void fillMatrixKernel(float* mat, BoundaryCheckStrategy* strategy, float mean, f
 
 using namespace std;
 
-void fill(float* mat, int m, int n, float mean = 0.0f, float stddev = 1.0f) {
+void fill(float* mat, uint m, uint n, float mean = 0.0f, float stddev = 1.0f) {
     float* d_mat;
     size_t size = m * n * sizeof(float);
 
@@ -41,11 +44,17 @@ void fill(float* mat, int m, int n, float mean = 0.0f, float stddev = 1.0f) {
     }
 
     // Configure kernel launch parameters
-    float threadsPerBlock = 16.0f;
-    dim3 gridDim { ceil(n / threadsPerBlock), ceil(m / threadsPerBlock), 1 };
-    dim3 blockDim { n, m, 1 };
+    // Each block will handle 16x16 threads
+    uint threadsPerBlockDim = 16;
+    // The grid will be sized to cover the entire matrix, rows (m)
+    // in the y dimension and columns (n) in the x dimension.
+    dim3 gridDim { 
+        static_cast<uint>(ceil(n / threadsPerBlockDim) + 1), 
+        static_cast<uint>(ceil(m / threadsPerBlockDim) + 1)};
+    dim3 blockDim { threadsPerBlockDim, threadsPerBlockDim };
+    printf("Grid dimensions: %d x %d, Block dimensions: %d x %d\n", 
+           gridDim.x, gridDim.y, blockDim.x, blockDim.y);
 
-    // TODO: Use a dim3 to initialize the strategy
     RectangularCheckStrategy strategy(m, n);
     RectangularCheckStrategy* d_strategy;
     err = cudaMalloc(&d_strategy, sizeof(RectangularCheckStrategy));
@@ -83,10 +92,16 @@ void fill(float* mat, int m, int n, float mean = 0.0f, float stddev = 1.0f) {
 }
 
 
-int main() {
-    // Example usage of fill function
-    const int M = 3;
-    const int N = 4;
+int main(int argc, char* argv[]) {
+    // Default values for matrix dimensions
+    int M = 10;
+    int N = 15;
+
+    // Parse command line arguments if provided
+    if (argc > 1) M = atoi(argv[1]);
+    if (argc > 2) N = atoi(argv[2]);
+
+    printf("Creating matrix of size %d x %d\n", M, N);
     float* matrix = new float[M * N];
 
     fill(matrix, M, N);  // Using default mean=0.0 and stddev=1.0


### PR DESCRIPTION
`nvcc` does not support vtables, so we need to replace `virtual` functions (and polymorphism) with more basic `if/then` or `switch` constructs.

The first commit in this PR (tagged at `0.1.1`) demonstrates the "classic" C++ approach: this leads to an "invalid program counter" error in the kernel function.

To fix the issue, we need to entirely remove the base class and the `virtual`/`override` constructs, and replace them with a more basic approach (tagged at `0.2.0`)