### PR TITLE
Added IAM Role for EC2

### DIFF
--- a/aws_access_options.md
+++ b/aws_access_options.md
@@ -1,0 +1,58 @@
+# Options for Enabling EC2 Instances to Access AWS Services
+
+Based on my analysis of your codebase, I've identified several options to allow your EC2 instances to access AWS services (like Secrets Manager) without manually adding credentials.
+
+## Option 1: IAM Roles for EC2 Instances with Instance Profiles
+
+### Description
+Create an IAM role with the necessary permissions (e.g., for Secrets Manager access) and attach it to EC2 instances using an instance profile when launching them.
+
+### Implementation
+1. Create an IAM role with appropriate permissions
+2. Create an instance profile and associate it with the role
+3. Modify the EC2 launch code to include the instance profile ARN
+
+### Pros
+- **Best Practice**: This is the AWS recommended approach for EC2 instances
+- **Security**: No credentials stored on the instance; temporary credentials are automatically rotated
+- **Simplicity**: Once set up, no additional configuration needed on the instance
+- **Granular Control**: Can define specific permissions for different instance types/purposes
+
+### Cons
+- **Setup Required**: Requires creating and managing IAM roles and policies
+- **Immutable**: Role can't be changed after instance launch (would need to stop/start or relaunch)
+
+## Option 2: AWS Systems Manager (SSM) Parameter Store or Secrets Manager with Default Credentials Provider Chain
+
+### Description
+Use the AWS SDK's default credential provider chain, which can use instance metadata credentials if available.
+
+### Pros
+- **Flexibility**: Can store configuration, secrets, and other parameters
+- **Versioning**: Supports versioning of parameters/secrets
+
+### Cons
+- **Still Needs IAM Role**: Still requires an IAM role for the EC2 instance
+- **More Complex**: More complex to set up than just using IAM roles directly
+
+## Option 3: EC2 Instance Connect
+
+### Description
+Use EC2 Instance Connect to establish SSH connections to your instances without storing SSH keys.
+
+### Pros
+- **Simplified SSH Access**: No need to manage SSH keys on instances
+- **Audit Trail**: Connections are logged in CloudTrail
+
+### Cons
+- **Limited Use Case**: Only solves SSH access, not general AWS service access
+- **Still Needs IAM Permissions**: Users still need IAM permissions to use Instance Connect
+
+## Recommendation
+
+**Option 1 (IAM Roles with Instance Profiles)** is the most recommended approach because:
+
+1. It follows AWS best practices for security
+2. It's the simplest to implement and maintain
+3. It doesn't require storing credentials on the instance
+4. It provides fine-grained control over permissions

--- a/go-aws-cli/README.md
+++ b/go-aws-cli/README.md
@@ -75,6 +75,41 @@ To SSH into the instance use:
   ssh -i private/gpu-key.pem ubuntu@<public-ip>
 ```
 
+## IAM Role for EC2 Instances
+
+The CLI automatically creates and attaches an IAM role and instance profile to EC2 instances, enabling them to access AWS services without manual credential management.
+
+### What's Created
+
+- **IAM Role**: A role named `<project-tag>-ec2-role` with a trust policy allowing EC2 instances to assume it
+- **Instance Profile**: A profile named `<project-tag>-ec2-instance-profile` that's attached to the EC2 instance
+
+### Permissions
+
+The IAM role has the following managed policies attached:
+
+- **AmazonSSMManagedInstanceCore**: Allows the instance to use AWS Systems Manager
+- **SecretsManagerReadWrite**: Allows the instance to read and write secrets in AWS Secrets Manager
+
+### Benefits
+
+- **No Manual Credentials**: EC2 instances can access AWS services without storing credentials on the instance
+- **Automatic Rotation**: AWS automatically rotates the temporary credentials
+- **Secure**: Follows AWS best practices for security
+- **Simplified Setup**: The `aws` CLI on the instance works without additional configuration
+
+### Usage on the Instance
+
+Once connected to the instance, you can use the AWS CLI without additional configuration:
+
+```bash
+# Example: Retrieve a secret from Secrets Manager
+aws secretsmanager get-secret-value --secret-id "my-secret"
+
+# Example: List S3 buckets
+aws s3 ls
+```
+
 ## Development
 
 ### Project Structure
@@ -83,6 +118,7 @@ To SSH into the instance use:
 - `pkg/common/`: Common utilities and AWS configuration
 - `pkg/vpc/`: VPC-related functionality
 - `pkg/ec2/`: EC2-related functionality
+- `pkg/iam/`: IAM role and instance profile functionality
 
 ### Building from Source
 

--- a/go-aws-cli/cmd/main.go
+++ b/go-aws-cli/cmd/main.go
@@ -62,14 +62,14 @@ func main() {
 
 			// Create VPC infrastructure
 			vpcClient := vpc.NewVPCClient(cfg)
-			vpcID, subnetID, err := vpcClient.SetupVPC(projectTag, vpcCidr, subnetCidr)
+			vpcID, subnetID, instanceProfileArn, err := vpcClient.SetupVPC(projectTag, vpcCidr, subnetCidr)
 			if err != nil {
 				return fmt.Errorf("failed to setup VPC: %v", err)
 			}
 
 			// Create EC2 instance
 			ec2Client := ec2.NewEC2Client(cfg)
-			instanceID, publicIP, err := ec2Client.SetupEC2(projectTag, vpcID, subnetID, keyName, instanceType)
+			instanceID, publicIP, err := ec2Client.SetupEC2(projectTag, vpcID, subnetID, keyName, instanceType, instanceProfileArn)
 			if err != nil {
 				return fmt.Errorf("failed to setup EC2 instance: %v", err)
 			}
@@ -93,10 +93,14 @@ func main() {
 			fmt.Printf("Successfully created infrastructure:\n")
 			fmt.Printf("VPC ID: %s\n", vpcID)
 			fmt.Printf("Subnet ID: %s\n", subnetID)
+			fmt.Printf("IAM Instance Profile: %s\n", instanceProfileArn)
 			fmt.Printf("Instance ID: %s\n", instanceID)
 			fmt.Printf("Public IP: %s\n", publicIP)
 			fmt.Printf("To SSH into the instance use:\n")
 			fmt.Printf("  ssh -i private/%s.pem ubuntu@%s\n", keyName, publicIP)
+			fmt.Printf("\nTo copy and run the setup script:\n")
+			fmt.Printf("  scp -i private/%s.pem scripts/setup-host.sh ubuntu@%s:~/\n", keyName, publicIP)
+			fmt.Printf("  ssh -i private/%s.pem ubuntu@%s \"chmod +x ~/setup-host.sh && ~/setup-host.sh\"\n", keyName, publicIP)
 
 			return nil
 		},
@@ -116,7 +120,7 @@ func main() {
 
 			// Create VPC infrastructure
 			vpcClient := vpc.NewVPCClient(cfg)
-			vpcID, subnetID, err := vpcClient.SetupVPC(projectTag, vpcCidr, subnetCidr)
+			vpcID, subnetID, instanceProfileArn, err := vpcClient.SetupVPC(projectTag, vpcCidr, subnetCidr)
 			if err != nil {
 				return fmt.Errorf("failed to setup VPC: %v", err)
 			}
@@ -124,6 +128,7 @@ func main() {
 			fmt.Printf("Successfully created VPC infrastructure:\n")
 			fmt.Printf("VPC ID: %s\n", vpcID)
 			fmt.Printf("Subnet ID: %s\n", subnetID)
+			fmt.Printf("IAM Instance Profile ARN: %s\n", instanceProfileArn)
 
 			return nil
 		},
@@ -143,7 +148,7 @@ func main() {
 
 			// Find VPC by tag
 			vpcClient := vpc.NewVPCClient(cfg)
-			vpcID, subnetID, err := vpcClient.SetupVPC(projectTag, vpcCidr, subnetCidr)
+			vpcID, subnetID, instanceProfileArn, err := vpcClient.SetupVPC(projectTag, vpcCidr, subnetCidr)
 			if err != nil {
 				return fmt.Errorf("failed to find VPC: %v", err)
 			}
@@ -154,7 +159,7 @@ func main() {
 
 			// Create EC2 instance
 			ec2Client := ec2.NewEC2Client(cfg)
-			instanceID, publicIP, err := ec2Client.SetupEC2(projectTag, vpcID, subnetID, keyName, instanceType)
+			instanceID, publicIP, err := ec2Client.SetupEC2(projectTag, vpcID, subnetID, keyName, instanceType, instanceProfileArn)
 			if err != nil {
 				return fmt.Errorf("failed to setup EC2 instance: %v", err)
 			}
@@ -176,10 +181,14 @@ func main() {
 			}
 
 			fmt.Printf("Successfully created EC2 instance:\n")
+			fmt.Printf("IAM Instance Profile: %s\n", instanceProfileArn)
 			fmt.Printf("Instance ID: %s\n", instanceID)
 			fmt.Printf("Public IP: %s\n", publicIP)
 			fmt.Printf("To SSH into the instance use:\n")
 			fmt.Printf("  ssh -i private/%s.pem ubuntu@%s\n", keyName, publicIP)
+			fmt.Printf("\nTo copy and run the setup script:\n")
+			fmt.Printf("  scp -i private/%s.pem scripts/setup-host.sh ubuntu@%s:~/\n", keyName, publicIP)
+			fmt.Printf("  ssh -i private/%s.pem ubuntu@%s \"chmod +x ~/setup-host.sh && ~/setup-host.sh\"\n", keyName, publicIP)
 
 			return nil
 		},

--- a/go-aws-cli/go.mod
+++ b/go-aws-cli/go.mod
@@ -3,14 +3,15 @@ module github.com/cuda-learn/go-aws-cli
 go 1.24.2
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.36.5 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.36.6 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.29.17 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.70 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.32 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.36 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.36 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.37 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.37 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.232.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/iam v1.43.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.7 // indirect

--- a/go-aws-cli/go.sum
+++ b/go-aws-cli/go.sum
@@ -1,5 +1,7 @@
 github.com/aws/aws-sdk-go-v2 v1.36.5 h1:0OF9RiEMEdDdZEMqF9MRjevyxAQcf6gY+E7vwBILFj0=
 github.com/aws/aws-sdk-go-v2 v1.36.5/go.mod h1:EYrzvCCN9CMUTa5+6lf6MM4tq3Zjp8UhSGR/cBsjai0=
+github.com/aws/aws-sdk-go-v2 v1.36.6 h1:zJqGjVbRdTPojeCGWn5IR5pbJwSQSBh5RWFTQcEQGdU=
+github.com/aws/aws-sdk-go-v2 v1.36.6/go.mod h1:EYrzvCCN9CMUTa5+6lf6MM4tq3Zjp8UhSGR/cBsjai0=
 github.com/aws/aws-sdk-go-v2/config v1.29.17 h1:jSuiQ5jEe4SAMH6lLRMY9OVC+TqJLP5655pBGjmnjr0=
 github.com/aws/aws-sdk-go-v2/config v1.29.17/go.mod h1:9P4wwACpbeXs9Pm9w1QTh6BwWwJjwYvJ1iCt5QbCXh8=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.70 h1:ONnH5CM16RTXRkS8Z1qg7/s2eDOhHhaXVd72mmyv4/0=
@@ -8,12 +10,18 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.32 h1:KAXP9JSHO1vKGCr5f4O6Wm
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.32/go.mod h1:h4Sg6FQdexC1yYG9RDnOvLbW1a/P986++/Y/a+GyEM8=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.36 h1:SsytQyTMHMDPspp+spo7XwXTP44aJZZAC7fBV2C5+5s=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.36/go.mod h1:Q1lnJArKRXkenyog6+Y+zr7WDpk4e6XlR6gs20bbeNo=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.37 h1:osMWfm/sC/L4tvEdQ65Gri5ZZDCUpuYJZbTTDrsn4I0=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.37/go.mod h1:ZV2/1fbjOPr4G4v38G3Ww5TBT4+hmsK45s/rxu1fGy0=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.36 h1:i2vNHQiXUvKhs3quBR6aqlgJaiaexz/aNvdCktW/kAM=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.36/go.mod h1:UdyGa7Q91id/sdyHPwth+043HhmP6yP9MBHgbZM0xo8=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.37 h1:v+X21AvTb2wZ+ycg1gx+orkB/9U6L7AOp93R7qYxsxM=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.37/go.mod h1:G0uM1kyssELxmJ2VZEfG0q2npObR3BAkF3c1VsfVnfs=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.232.0 h1:UPPzQR5eKqKWNRdGh1YLNYvUftQL5YH+Jawr0gp2dM0=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.232.0/go.mod h1:35jGWx7ECvCwTsApqicFYzZ7JFEnBc6oHUuOQ3xIS54=
+github.com/aws/aws-sdk-go-v2/service/iam v1.43.1 h1:xpPZZpbmqIJse9OH+Kf/bW/n+bRe0BtE/LtHvBJYcbc=
+github.com/aws/aws-sdk-go-v2/service/iam v1.43.1/go.mod h1:/IEkOg5Gkv2HFxOb3Prs84xpRyxO9P/9Zow/clWl84Q=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4 h1:CXV68E2dNqhuynZJPB80bhPQwAKqBWVer887figW6Jc=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4/go.mod h1:/xFi9KtvBXP97ppCz1TAEvU1Uf66qvid89rbem3wCzQ=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17 h1:t0E6FzREdtCsiLIoLCWsYliNsRBgyGD/MCK571qk4MI=

--- a/go-aws-cli/pkg/ec2/ec2.go
+++ b/go-aws-cli/pkg/ec2/ec2.go
@@ -16,6 +16,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"github.com/cuda-learn/go-aws-cli/pkg/iam"
 	"os"
 	"path/filepath"
 	"sort"
@@ -47,7 +48,7 @@ func NewEC2Client(cfg aws.Config) *EC2Client {
 }
 
 // SetupEC2 creates an EC2 instance
-func (e *EC2Client) SetupEC2(projectTag, vpcID, subnetID, keyName, instanceType string) (string, string, error) {
+func (e *EC2Client) SetupEC2(projectTag, vpcID, subnetID, keyName, instanceType, instanceProfileArn string) (string, string, error) {
 	// Create or find security group
 	sgID, err := e.vpcClient.CreateSecurityGroup(vpcID, projectTag)
 	if err != nil {
@@ -75,6 +76,7 @@ func (e *EC2Client) SetupEC2(projectTag, vpcID, subnetID, keyName, instanceType 
 	if err != nil {
 		return "", "", fmt.Errorf("failed to launch instance: %w", err)
 	}
+	common.LogInfo("Attached IAM Instance Profile: %s to instance", instanceProfileArn)
 	common.LogInfo("Launched instance: %s with project tag: %s", instanceID, projectTag)
 
 	// Wait for instance to be running
@@ -378,6 +380,13 @@ func (e *EC2Client) launchInstance(amiID, instanceType, keyName, sgID, subnetID,
 		SecurityGroupIds:  []string{sgID},
 		SubnetId:          aws.String(subnetID),
 		TagSpecifications: tagSpecifications,
+	}
+
+	// Add IAM instance profile to enable access to AWS services.
+	profileName := iam.EC2InstanceProfileName(projectTag)
+	common.LogInfo("Attaching IAM instance profile: %s", profileName)
+	input.IamInstanceProfile = &types.IamInstanceProfileSpecification{
+		Name: aws.String(profileName),
 	}
 
 	resp, err := e.ec2Client.RunInstances(context.TODO(), input)

--- a/go-aws-cli/pkg/iam/iam.go
+++ b/go-aws-cli/pkg/iam/iam.go
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2025 AlertAvert.com.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Author: Marco Massenzio (marco@alertavert.com)
+ */
+
+package iam
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/cuda-learn/go-aws-cli/pkg/common"
+)
+
+// IAMClient handles IAM-related operations
+type IAMClient struct {
+	iamClient *iam.Client
+}
+
+// NewIAMClient creates a new IAM client
+func NewIAMClient(cfg aws.Config) *IAMClient {
+	return &IAMClient{
+		iamClient: iam.NewFromConfig(cfg),
+	}
+}
+
+// EC2RoleName returns the standard role name for EC2 instances
+func EC2RoleName(projectTag string) string {
+	return fmt.Sprintf("%s-ec2-role", projectTag)
+}
+
+// EC2InstanceProfileName returns the standard instance profile name for EC2 instances
+func EC2InstanceProfileName(projectTag string) string {
+	return fmt.Sprintf("%s-profile", projectTag)
+}
+
+// SetupEC2Role creates an IAM role and instance profile for EC2 instances if they don't exist
+// Returns the instance profile ARN
+func (i *IAMClient) SetupEC2Role(projectTag string) (string, error) {
+	roleName := EC2RoleName(projectTag)
+	profileName := EC2InstanceProfileName(projectTag)
+
+	// Check if role exists
+	roleArn, err := i.findRoleByName(roleName)
+	if err != nil {
+		return "", fmt.Errorf("error finding role: %w", err)
+	}
+
+	// Create role if it doesn't exist
+	if roleArn == "" {
+		common.LogInfo("Creating IAM role: %s", roleName)
+		roleArn, err = i.createEC2Role(roleName, projectTag)
+		if err != nil {
+			return "", fmt.Errorf("failed to create role: %w", err)
+		}
+		common.LogSuccess("Created IAM role: %s with ARN: %s", roleName, roleArn)
+
+		// Attach policies to the role
+		err = i.attachPolicyToRole(roleName, "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore")
+		if err != nil {
+			return "", fmt.Errorf("failed to attach SSM policy: %w", err)
+		}
+
+		err = i.attachPolicyToRole(roleName, "arn:aws:iam::aws:policy/SecretsManagerReadWrite")
+		if err != nil {
+			return "", fmt.Errorf("failed to attach Secrets Manager policy: %w", err)
+		}
+		common.LogInfo("Attached policies to role: %s", roleName)
+	} else {
+		common.LogInfo("Found existing IAM role: %s with ARN: %s", roleName, roleArn)
+	}
+
+	// Check if instance profile exists
+	profileArn, err := i.findInstanceProfileByName(profileName)
+	if err != nil {
+		return "", fmt.Errorf("error finding instance profile: %w", err)
+	}
+
+	// Create instance profile if it doesn't exist
+	if profileArn == "" {
+		common.LogInfo("Creating IAM instance profile: %s", profileName)
+		profileArn, err = i.createInstanceProfile(profileName, roleName)
+		if err != nil {
+			return "", fmt.Errorf("failed to create instance profile: %w", err)
+		}
+		common.LogSuccess("Created IAM instance profile: %s with ARN: %s", profileName, profileArn)
+	} else {
+		common.LogInfo("Found existing IAM instance profile: %s with ARN: %s", profileName, profileArn)
+	}
+
+	return profileArn, nil
+}
+
+// findRoleByName finds an IAM role by name
+// Returns the role ARN if found, empty string if not found
+func (i *IAMClient) findRoleByName(roleName string) (string, error) {
+	input := &iam.GetRoleInput{
+		RoleName: aws.String(roleName),
+	}
+
+	resp, err := i.iamClient.GetRole(context.TODO(), input)
+	if err != nil {
+		// If the role doesn't exist, AWS returns an error
+		if strings.Contains(err.Error(), "NoSuchEntity") {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to get role: %w", err)
+	}
+
+	return *resp.Role.Arn, nil
+}
+
+// findInstanceProfileByName finds an IAM instance profile by name
+// Returns the instance profile ARN if found, empty string if not found
+func (i *IAMClient) findInstanceProfileByName(profileName string) (string, error) {
+	input := &iam.GetInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+	}
+
+	resp, err := i.iamClient.GetInstanceProfile(context.TODO(), input)
+	if err != nil {
+		// If the instance profile doesn't exist, AWS returns an error
+		if strings.Contains(err.Error(), "NoSuchEntity") {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to get instance profile: %w", err)
+	}
+
+	return *resp.InstanceProfile.Arn, nil
+}
+
+// createEC2Role creates an IAM role for EC2 instances
+func (i *IAMClient) createEC2Role(roleName string, projectTag string) (string, error) {
+	// Trust policy document for EC2
+	trustPolicy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Principal": {
+					"Service": "ec2.amazonaws.com"
+				},
+				"Action": "sts:AssumeRole"
+			}
+		]
+	}`
+
+	input := &iam.CreateRoleInput{
+		RoleName:                 aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+		Description:              aws.String(fmt.Sprintf("Role for EC2 instances in %s project", projectTag)),
+		Tags: []types.Tag{
+			{
+				Key:   aws.String("project"),
+				Value: aws.String(projectTag),
+			},
+		},
+	}
+
+	resp, err := i.iamClient.CreateRole(context.TODO(), input)
+	if err != nil {
+		return "", fmt.Errorf("failed to create role: %w", err)
+	}
+
+	return *resp.Role.Arn, nil
+}
+
+// attachPolicyToRole attaches a policy to an IAM role
+func (i *IAMClient) attachPolicyToRole(roleName string, policyArn string) error {
+	input := &iam.AttachRolePolicyInput{
+		RoleName:  aws.String(roleName),
+		PolicyArn: aws.String(policyArn),
+	}
+
+	_, err := i.iamClient.AttachRolePolicy(context.TODO(), input)
+	if err != nil {
+		return fmt.Errorf("failed to attach policy: %w", err)
+	}
+
+	return nil
+}
+
+// createInstanceProfile creates an IAM instance profile and attaches the role
+func (i *IAMClient) createInstanceProfile(profileName string, roleName string) (string, error) {
+	// Create instance profile
+	createInput := &iam.CreateInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+	}
+
+	createResp, err := i.iamClient.CreateInstanceProfile(context.TODO(), createInput)
+	if err != nil {
+		return "", fmt.Errorf("failed to create instance profile: %w", err)
+	}
+
+	// Add role to instance profile
+	addRoleInput := &iam.AddRoleToInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+		RoleName:            aws.String(roleName),
+	}
+
+	_, err = i.iamClient.AddRoleToInstanceProfile(context.TODO(), addRoleInput)
+	if err != nil {
+		return "", fmt.Errorf("failed to add role to instance profile: %w", err)
+	}
+
+	return *createResp.InstanceProfile.Arn, nil
+}

--- a/go-aws-cli/pkg/vpc/vpc.go
+++ b/go-aws-cli/pkg/vpc/vpc.go
@@ -18,26 +18,36 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cuda-learn/go-aws-cli/pkg/common"
+	"github.com/cuda-learn/go-aws-cli/pkg/iam"
 )
 
 // VPCClient handles VPC-related operations
 type VPCClient struct {
-	client *ec2.Client
+	client   *ec2.Client
+	iamClient *iam.IAMClient
 }
 
 // NewVPCClient creates a new VPC client
 func NewVPCClient(cfg aws.Config) *VPCClient {
 	return &VPCClient{
-		client: ec2.NewFromConfig(cfg),
+		client:    ec2.NewFromConfig(cfg),
+		iamClient: iam.NewIAMClient(cfg),
 	}
 }
 
 // SetupVPC creates or finds a VPC with the specified tag
-func (v *VPCClient) SetupVPC(projectTag, vpcCidr, subnetCidr string) (string, string, error) {
+// Returns VPC ID, subnet ID, instance profile ARN, and error
+func (v *VPCClient) SetupVPC(projectTag, vpcCidr, subnetCidr string) (string, string, string, error) {
 	// Check if VPC with tag exists
 	vpcID, err := v.findVPCByTag(projectTag)
 	if err != nil {
-		return "", "", fmt.Errorf("error finding VPC: %w", err)
+		return "", "", "", fmt.Errorf("error finding VPC: %w", err)
+	}
+
+	// Setup IAM role and instance profile for EC2 instances
+	profileArn, err := v.iamClient.SetupEC2Role(projectTag)
+	if err != nil {
+		return "", "", "", fmt.Errorf("error setting up IAM role: %w", err)
 	}
 
 	// If VPC exists, find subnet
@@ -47,49 +57,49 @@ func (v *VPCClient) SetupVPC(projectTag, vpcCidr, subnetCidr string) (string, st
 		// Find subnet in the VPC
 		subnetID, err := v.findSubnetByTag(vpcID, projectTag)
 		if err != nil {
-			return "", "", fmt.Errorf("error finding subnet: %w", err)
+			return "", "", "", fmt.Errorf("error finding subnet: %w", err)
 		}
 
 		if subnetID == "" {
-			return "", "", fmt.Errorf("no subnet found in VPC %s with tag project=%s", vpcID, projectTag)
+			return "", "", "", fmt.Errorf("no subnet found in VPC %s with tag project=%s", vpcID, projectTag)
 		}
 
 		common.LogInfo("Found existing Subnet: %s", subnetID)
-		return vpcID, subnetID, nil
+		return vpcID, subnetID, profileArn, nil
 	}
 
 	// Create new VPC
 	common.LogInfo("No existing VPC found. Creating new one...")
 	vpcID, err = v.createVPC(projectTag, vpcCidr)
 	if err != nil {
-		return "", "", fmt.Errorf("error creating VPC: %w", err)
+		return "", "", "", fmt.Errorf("error creating VPC: %w", err)
 	}
 
 	// Create subnet
 	subnetID, err := v.createSubnet(vpcID, projectTag, subnetCidr)
 	if err != nil {
-		return "", "", fmt.Errorf("error creating subnet: %w", err)
+		return "", "", "", fmt.Errorf("error creating subnet: %w", err)
 	}
 
 	// Create and attach internet gateway
 	igwID, err := v.createAndAttachInternetGateway(vpcID)
 	if err != nil {
-		return "", "", fmt.Errorf("error creating/attaching internet gateway: %w", err)
+		return "", "", "", fmt.Errorf("error creating/attaching internet gateway: %w", err)
 	}
 
 	// Create route table and routes
 	_, err = v.createRouteTable(vpcID, subnetID, igwID)
 	if err != nil {
-		return "", "", fmt.Errorf("error creating route table: %w", err)
+		return "", "", "", fmt.Errorf("error creating route table: %w", err)
 	}
 
 	// Enable auto-assign public IP
 	err = v.enableAutoAssignPublicIP(subnetID)
 	if err != nil {
-		return "", "", fmt.Errorf("error enabling auto-assign public IP: %w", err)
+		return "", "", "", fmt.Errorf("error enabling auto-assign public IP: %w", err)
 	}
 
-	return vpcID, subnetID, nil
+	return vpcID, subnetID, profileArn, nil
 }
 
 // findVPCByTag finds a VPC with the specified tag

--- a/scripts/setup-host.sh
+++ b/scripts/setup-host.sh
@@ -6,14 +6,29 @@
 # http://www.apache.org/licenses/LICENSE-2.0
 #
 # Author: Marco Massenzio (marco@alertavert.com)
-#
+set -eu
 
 git config --global init.defaultBranch main
 git config --global user.name "Marco Massenzio"
 git config --global user.email "marco@massenz.io"
 
+# Download the private key from Secrets Manager
+SECRET_NAME=${1:-"gh-auth"}
+OUTPUT_FILE=~/.ssh/${SECRET_NAME}.pem
+AWS_REGION=$(curl -s --connect-timeout 2 \
+    http://169.254.169.254/latest/meta-data/placement/region || echo "us-west-2")
+
+echo "Downloading secret key '${SECRET_NAME}' from AWS Secrets Manager."
+echo "Using AWS region: ${AWS_REGION}"
+
+mkdir -p ~/.ssh
+aws secretsmanager get-secret-value --secret-id "${SECRET_NAME}" \
+    --region "${AWS_REGION}" \
+    --query SecretString --output text > "${OUTPUT_FILE}"
+chmod 600 "${OUTPUT_FILE}"
+
 eval "$(ssh-agent -s)"
-ssh-add ~/.ssh/gh.pem
+ssh-add "${OUTPUT_FILE}"
 
 git clone git@github.com:massenz/cuda-learn.git && \
     cd cuda-learn && \


### PR DESCRIPTION
To enable the use of `aws` CLI from the EC2 instance without the tedious (and insecure) copying of credentials, we attach an IAM Role to the instance, with the necessary permissions to access AWS services.

This allows accessing SecretsManager to download the SSH key to access GitHub and clone/commit code.