### PR TITLE
Improved teardown command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ You can run the CLI tool directly with various flags:
 - `setup`: Sets up both VPC and EC2 infrastructure
 - `vpc`: Sets up only VPC infrastructure
 - `instance`: Sets up only EC2 instance (requires VPC to exist)
+- `teardown`: Terminates EC2 instances with the specified project tag
 
 #### Available Flags
 
@@ -72,6 +73,15 @@ You can run the CLI tool directly with various flags:
 - `--subnet-cidr`: Subnet CIDR block (default: 10.0.1.0/24)
 - `--key-name`: SSH key name (default: gpu-key)
 - `--instance-type`: EC2 instance type (default: g4dn.xlarge)
+
+#### Teardown Command Flags
+
+The `teardown` command has additional flags for more control:
+
+- `--instance`: Specifies an instance ID to terminate (must match the project tag)
+- `--all`: Terminates all instances with matching project tag
+
+If neither flag is specified and multiple instances match the project tag, an interactive selection menu will be displayed.
 
 ## Connecting to the EC2 Instance
 

--- a/go-aws-cli/README.md
+++ b/go-aws-cli/README.md
@@ -22,13 +22,13 @@ This CLI tool automates the creation of AWS infrastructure for CUDA-Learn projec
 
 1. Clone the repository:
    ```
-   git clone https://github.com/cuda-learn/go-aws-cli.git
-   cd go-aws-cli
+   git clone git@github.com:massenz/cuda-learn.git
+   cd cuda-learn
    ```
 
 2. Build the CLI:
    ```
-   go build -o aws-cli ./cmd
+   make cli
    ```
 
 ## Usage
@@ -38,7 +38,7 @@ This CLI tool automates the creation of AWS infrastructure for CUDA-Learn projec
 To create the infrastructure with default settings:
 
 ```
-./aws-cli setup
+./build/cuda-learn setup
 ```
 
 This will:
@@ -54,8 +54,15 @@ This will:
 You can customize the infrastructure creation with various flags:
 
 ```
-./aws-cli setup --region us-east-1 --project my-project --vpc-cidr 192.168.0.0/16 --subnet-cidr 192.168.1.0/24 --key-name my-key --instance-type p3.2xlarge
+./build/cuda-learn setup --region us-east-1 --project my-project --vpc-cidr 192.168.0.0/16 --subnet-cidr 192.168.1.0/24 --key-name my-key --instance-type p3.2xlarge
 ```
+
+### Available Commands
+
+- `setup`: Sets up both VPC and EC2 infrastructure
+- `vpc`: Sets up only VPC infrastructure
+- `instance`: Sets up only EC2 instance (requires VPC to exist)
+- `teardown`: Terminates EC2 instances with the specified project tag
 
 ### Available Flags
 
@@ -63,8 +70,30 @@ You can customize the infrastructure creation with various flags:
 - `--project`: Project tag value (default: cuda-learn)
 - `--vpc-cidr`: VPC CIDR block (default: 10.0.0.0/16)
 - `--subnet-cidr`: Subnet CIDR block (default: 10.0.1.0/24)
-- `--key-name`: SSH key name (default: gpu-key)
+- `--key-name`: SSH key name for EC2 instance access (default: gpu-key)
 - `--instance-type`: EC2 instance type (default: g4dn.xlarge)
+- `--gh-auth`: Path to PEM key for GitHub authentication (optional)
+- `--gh-auth-key-name`: Name for GitHub authentication key in SecretsManager (default: gh-auth)
+
+### Teardown Command
+
+The `teardown` command allows you to terminate EC2 instances with the specified project tag. It has additional flags for more control:
+
+- `--instance`: Specifies an instance ID to terminate (must match the project tag)
+- `--all`: Terminates all instances with matching project tag
+
+If neither flag is specified and multiple instances match the project tag, an interactive selection menu will be displayed:
+
+```
+More than one instance matches the `project=cuda-learn` tag:
+<< details of instances>>
+Which one would you like to terminate:
+1) id-12345
+2) id-9876
+3) id-88754
+
+Please choose one (or simply Enter to exit): 
+```
 
 ## SSH Access
 
@@ -82,7 +111,7 @@ The CLI automatically creates and attaches an IAM role and instance profile to E
 ### What's Created
 
 - **IAM Role**: A role named `<project-tag>-ec2-role` with a trust policy allowing EC2 instances to assume it
-- **Instance Profile**: A profile named `<project-tag>-ec2-instance-profile` that's attached to the EC2 instance
+- **Instance Profile**: A profile named `<project-tag>-profile` that's attached to the EC2 instance
 
 ### Permissions
 
@@ -110,6 +139,61 @@ aws secretsmanager get-secret-value --secret-id "my-secret"
 aws s3 ls
 ```
 
+## Command Line Help
+
+Below is the output of the `help` command showing all available commands and flags:
+
+```
+A CLI tool to create and manage AWS infrastructure for CUDA-Learn project.
+
+Usage:
+  cuda-learn [command]
+
+Available Commands:
+  help        Help about any command
+  instance    Setup EC2 instance
+  setup       Setup AWS infrastructure
+  teardown    Terminate EC2 instance
+  vpc         Setup VPC infrastructure
+
+Flags:
+      --gh-auth string              Path to PEM key for GitHub authentication
+      --gh-auth-key-name string     Name for GitHub authentication key in SecretsManager (default "gh-auth")
+  -h, --help                        help for cuda-learn
+      --instance-type string        EC2 instance type (default "g4dn.xlarge")
+      --key-name string             SSH key name (default "gpu-key")
+      --project string              Project tag value (default "cuda-learn")
+      --region string               AWS region (default "us-west-2")
+      --subnet-cidr string          Subnet CIDR block (default "10.0.1.0/24")
+      --vpc-cidr string             VPC CIDR block (default "10.0.0.0/16")
+
+Use "cuda-learn [command] --help" for more information about a command.
+```
+
+For the `teardown` command specifically:
+
+```
+Terminate EC2 instance with the specified project tag.
+
+Usage:
+  cuda-learn teardown [flags]
+
+Flags:
+      --all                Terminate all instances with matching project tag
+  -h, --help               help for teardown
+      --instance string    Instance ID to terminate (must match project tag)
+
+Global Flags:
+      --gh-auth string              Path to PEM key for GitHub authentication
+      --gh-auth-key-name string     Name for GitHub authentication key in SecretsManager (default "gh-auth")
+      --instance-type string        EC2 instance type (default "g4dn.xlarge")
+      --key-name string             SSH key name (default "gpu-key")
+      --project string              Project tag value (default "cuda-learn")
+      --region string               AWS region (default "us-west-2")
+      --subnet-cidr string          Subnet CIDR block (default "10.0.1.0/24")
+      --vpc-cidr string             VPC CIDR block (default "10.0.0.0/16")
+```
+
 ## Development
 
 ### Project Structure
@@ -119,19 +203,3 @@ aws s3 ls
 - `pkg/vpc/`: VPC-related functionality
 - `pkg/ec2/`: EC2-related functionality
 - `pkg/iam/`: IAM role and instance profile functionality
-
-### Building from Source
-
-```
-go build -o aws-cli ./cmd
-```
-
-### Running Tests
-
-```
-go test ./...
-```
-
-## License
-
-MIT

--- a/go-aws-cli/cmd/main.go
+++ b/go-aws-cli/cmd/main.go
@@ -215,15 +215,97 @@ func main() {
 				return fmt.Errorf("failed to find instances: %v", err)
 			}
 
-			// Handle the three possible outcomes
-			switch len(instances) {
-			case 0:
-				// No instances found
+			// Check if no instances found
+			if len(instances) == 0 {
 				common.LogError("No instances found with project tag: %s", projectTag)
-				return fmt.Errorf("no instances found with project tag: %s", projectTag)
+				fmt.Printf("No instances found with project tag: %s\n", projectTag)
+				return nil
+			}
 
-			case 1:
-				// One instance found, ask for confirmation
+			// Get flag values
+			specifiedInstanceID, _ := cmd.Flags().GetString("instance")
+			terminateAll, _ := cmd.Flags().GetBool("all")
+
+			// Check if both --all and --instance flags are specified
+			if specifiedInstanceID != "" && terminateAll {
+				common.LogError("Cannot specify both --all and --instance flags")
+				return fmt.Errorf("cannot specify both --all and --instance flags")
+			}
+
+			// If instance ID is specified, find and terminate that specific instance
+			if specifiedInstanceID != "" {
+				var found bool
+				var targetInstance int
+
+				for i, instance := range instances {
+					if *instance.InstanceId == specifiedInstanceID {
+						targetInstance = i
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					common.LogError("No instance with ID %s found with project tag: %s", specifiedInstanceID, projectTag)
+					fmt.Printf("No instance with ID %s found with project tag: %s\n", specifiedInstanceID, projectTag)
+					return nil
+				}
+
+				fmt.Println("Found the specified instance:")
+				fmt.Println(ec2Client.GetInstanceDetails(instances[targetInstance]))
+
+				// Ask for confirmation
+				fmt.Print("Do you want to terminate this instance? (yes/no): ")
+				var response string
+				fmt.Scanln(&response)
+
+				if strings.ToLower(response) == "yes" {
+					// Terminate the instance
+					err := ec2Client.TerminateInstance(specifiedInstanceID)
+					if err != nil {
+						return fmt.Errorf("failed to terminate instance: %v", err)
+					}
+					fmt.Println("Instance termination initiated successfully.")
+				} else {
+					fmt.Println("Instance termination cancelled.")
+				}
+
+				return nil
+			}
+
+			// If --all flag is specified, terminate all instances
+			if terminateAll {
+				fmt.Printf("Found %d instances with project tag %s:\n\n", len(instances), projectTag)
+				for _, instance := range instances {
+					fmt.Println(ec2Client.GetInstanceDetails(instance))
+					fmt.Println("---")
+				}
+
+				// Ask for confirmation
+				fmt.Printf("Do you want to terminate all %d instances? (yes/no): ", len(instances))
+				var response string
+				fmt.Scanln(&response)
+
+				if strings.ToLower(response) == "yes" {
+					// Terminate all instances
+					for _, instance := range instances {
+						instanceID := *instance.InstanceId
+						err := ec2Client.TerminateInstance(instanceID)
+						if err != nil {
+							fmt.Printf("Failed to terminate instance %s: %v\n", instanceID, err)
+							continue
+						}
+						fmt.Printf("Instance %s termination initiated successfully.\n", instanceID)
+					}
+				} else {
+					fmt.Println("Instance termination cancelled.")
+				}
+
+				return nil
+			}
+
+			// Handle single instance case
+			if len(instances) == 1 {
 				instance := instances[0]
 				fmt.Println("Found one instance with the specified project tag:")
 				fmt.Println(ec2Client.GetInstanceDetails(instance))
@@ -235,7 +317,8 @@ func main() {
 
 				if strings.ToLower(response) == "yes" {
 					// Terminate the instance
-					err := ec2Client.TerminateInstance(*instance.InstanceId)
+					instanceID := *instance.InstanceId
+					err := ec2Client.TerminateInstance(instanceID)
 					if err != nil {
 						return fmt.Errorf("failed to terminate instance: %v", err)
 					}
@@ -244,19 +327,68 @@ func main() {
 					fmt.Println("Instance termination cancelled.")
 				}
 
-			default:
-				// Multiple instances found
-				fmt.Printf("Found %d instances with the specified project tag:\n\n", len(instances))
-				for _, instance := range instances {
-					fmt.Println(ec2Client.GetInstanceDetails(instance))
-					fmt.Println("---")
+				return nil
+			}
+
+			// Multiple instances found and no flags specified - interactive selection
+			fmt.Printf("More than one instance matches the `project=%s` tag:\n\n", projectTag)
+			for _, instance := range instances {
+				fmt.Println(ec2Client.GetInstanceDetails(instance))
+				fmt.Println("---")
+			}
+
+			// List instance IDs for selection
+			fmt.Println("Which one would you like to terminate:")
+			for i, instance := range instances {
+				fmt.Printf("%d) %s\n", i+1, *instance.InstanceId)
+			}
+
+			// Get user selection
+			fmt.Print("\nPlease choose one (or simply Enter to exit): ")
+			var selection string
+			fmt.Scanln(&selection)
+
+			// Handle empty input (exit)
+			if selection == "" {
+				fmt.Println("No instance selected. Exiting.")
+				return nil
+			}
+
+			// Parse selection
+			var selectionNum int
+			_, err = fmt.Sscanf(selection, "%d", &selectionNum)
+			if err != nil || selectionNum < 1 || selectionNum > len(instances) {
+				return fmt.Errorf("invalid selection: %s", selection)
+			}
+
+			// Get selected instance
+			selectedInstance := instances[selectionNum-1]
+			selectedInstanceID := *selectedInstance.InstanceId
+			fmt.Printf("You selected instance %s\n", selectedInstanceID)
+
+			// Ask for confirmation
+			fmt.Print("Do you want to terminate this instance? (yes/no): ")
+			var response string
+			fmt.Scanln(&response)
+
+			if strings.ToLower(response) == "yes" {
+				// Terminate the instance
+				err := ec2Client.TerminateInstance(selectedInstanceID)
+				if err != nil {
+					return fmt.Errorf("failed to terminate instance: %v", err)
 				}
-				fmt.Println("Multiple instances found. Please specify a unique instance to terminate.")
+				fmt.Println("Instance termination initiated successfully.")
+			} else {
+				fmt.Println("Instance termination cancelled.")
 			}
 
 			return nil
 		},
 	}
+
+	// Add teardown-specific flags
+	teardownCmd.Flags().String("instance", "", "Instance ID to terminate (must match project tag)")
+	teardownCmd.Flags().Bool("all", false, "Terminate all instances with matching project tag")
 
 	// Add commands to root
 	rootCmd.AddCommand(setupCmd)


### PR DESCRIPTION
- Accepts two new flags: '--instance' and '--all';
- Allows selecting among multiple matching instances;
- if no match, it just prints a simple error message, and not the whole help.