### PR TITLE
Refactored the mat_gen.cu to be reusable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ version: ## Display the current version of the project
 	@echo "$(VERSION)"
 
 ##@ CUDA Application
+.PHONY: all build cpu-only
 all: build ## Default target to build CUDA applications
 
 build: ## Build CUDA applications using CMake

--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -27,13 +27,10 @@ set_target_properties(gpu-props PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${TARGET_DIR}
 )
 
-add_executable(mat-gen src/mat_gen.cu)
-set_target_properties(mat-gen PROPERTIES
-    CUDA_SEPARABLE_COMPILATION ON
-    RUNTIME_OUTPUT_DIRECTORY ${TARGET_DIR}
-    )
-
-add_executable(id-list-pool src/id-list-map.cu)
+add_executable(id-list-demo
+        src/id-list-map.cu
+        src/mat_gen.cu
+)
 set_target_properties(id-list-pool PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON
     RUNTIME_OUTPUT_DIRECTORY ${TARGET_DIR}

--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -27,11 +27,11 @@ set_target_properties(gpu-props PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${TARGET_DIR}
 )
 
-add_executable(id-list-demo
-        src/id-list-map.cu
+add_executable(demo 
+        src/demo.cpp
         src/mat_gen.cu
 )
-set_target_properties(id-list-pool PROPERTIES
+set_target_properties(demo PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON
     RUNTIME_OUTPUT_DIRECTORY ${TARGET_DIR}
 )
@@ -39,7 +39,7 @@ set_target_properties(id-list-pool PROPERTIES
 
 # Link against CUDA libraries
 target_link_libraries(gpu-props ${CUDA_LIBRARIES})
-target_link_libraries(mat-gen ${CUDA_LIBRARIES} ${CUDA_curand_LIBRARY})
+target_link_libraries(demo ${CUDA_LIBRARIES} ${CUDA_curand_LIBRARY})
 
 # Print information about the build
 message(STATUS "CUDA version: ${CUDA_VERSION}")

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -1,0 +1,57 @@
+#include <iostream>
+#include <iomanip>
+#include <string>
+#include <cstdlib>
+
+#include "fillmatrix.h"
+
+void printUsage() {
+    std::cout << "Usage: demo <command>\n";
+    std::cout << "Available commands:\n";
+    std::cout << "  fillmat    Fill a matrix with random values\n";
+}
+
+void printMatrix(float* mat, uint m, uint n) {
+    std::cout << std::fixed << std::setprecision(4);
+    for (uint i = 0; i < m; ++i) {
+        for (uint j = 0; j < n; ++j) {
+            std::cout << std::setw(8) << mat[i * n + j] << " ";
+        }
+        std::cout << std::endl;
+    }
+}
+
+void fillmat() {
+    // Create a small matrix for demonstration
+    const uint rows = 10;
+    const uint cols = 15;
+    float* matrix = new float[rows * cols];
+
+    // Fill the matrix with random values
+    fill(matrix, rows, cols);
+
+    // Print the matrix
+    std::cout << "Generated " << rows << "x" << cols << " matrix:\n";
+    printMatrix(matrix, rows, cols);
+
+    // Clean up
+    delete[] matrix;
+}
+
+int main(int argc, char* argv[]) {
+    if (argc != 2) {
+        printUsage();
+        return 1;
+    }
+
+    std::string command(argv[1]);
+    
+    if (command == "fillmat") {
+        fillmat();
+        return 0;
+    }
+
+    std::cout << "Unknown command: " << command << std::endl;
+    printUsage();
+    return 1;
+}

--- a/src/fillmatrix.h
+++ b/src/fillmatrix.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2025.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Author: Marco Massenzio (marco@alertavert.com)
+#pragma once
+#include <sys/types.h>
+
+
+/**
+ * @file mat_gen.cu
+ * @brief CUDA kernel to fill a matrix with random values from a normal distribution.
+ *
+ * This file contains the implementation of a CUDA kernel that fills a matrix
+ * with random values drawn from a normal distribution using the CURAND library.
+ * The kernel is designed to work with matrices of arbitrary size and allows
+ * for specifying the mean and standard deviation of the distribution.
+ *
+ * The strategy used here to check for the boundaries of the matrix is a `RectangularCheckStrategy`.
+ *
+ * @param mat Pointer to the matrix to fill, must have enough space allocated.
+ * @param strategy Pointer to a strategy object that defines the boundary checks.
+ * @param mean Mean of the normal distribution.
+ * @param stddev Standard deviation of the normal distribution.
+ * @param seed Seed for the random number generator.
+ */
+void fillMatrixKernel(float* mat, void* strategy, float mean, float stddev, unsigned long seed);
+
+/**
+ * Fills a matrix with random values drawn from a normal distribution.
+ *
+ * Example usage:
+ *     float* matrix = new float[M * N];
+ *     // Using default mean=0.0 and stddev=1.0
+ *     fill(matrix, M, N);
+ *
+ * @param mat Pointer to the matrix to fill, must have enough space allocated.
+ * @param m Number of rows in the matrix.
+ * @param n Number of columns in the matrix.
+ * @param mean Mean of the normal distribution.
+ * @param stddev Standard deviation of the normal distribution.
+ */
+void fill(float* mat, uint m, uint n, float mean = 0.0f, float stddev = 1.0f);

--- a/src/fillmatrix.h
+++ b/src/fillmatrix.h
@@ -6,6 +6,7 @@
 // Author: Marco Massenzio (marco@alertavert.com)
 #pragma once
 #include <sys/types.h>
+#include <cuda_runtime.h>
 
 
 /**
@@ -25,6 +26,7 @@
  * @param stddev Standard deviation of the normal distribution.
  * @param seed Seed for the random number generator.
  */
+__global__
 void fillMatrixKernel(float* mat, void* strategy, float mean, float stddev, unsigned long seed);
 
 /**

--- a/src/mat_gen.cu
+++ b/src/mat_gen.cu
@@ -12,14 +12,17 @@
 #include <memory>
 
 #include "boundaries.h"
+#include "fillmatrix.h"
 
-__global__ 
+using namespace std;
+
+__global__
 void fillMatrixKernel(float* mat, void* strategy, float mean, float stddev, unsigned long seed) {
 
     // Here we lose the flexibility of polymorphic behavior,
     // as we need to know in advance the type of strategy.
     // However, in kernel functions, we must know in advance the
-    // arrangement of data.
+    // arrangement of data anyway.
     SizeCheck checker { strategy, BoundaryType::Rectangular };
     if (checker()) {
         auto idx = checker.idx();
@@ -28,9 +31,6 @@ void fillMatrixKernel(float* mat, void* strategy, float mean, float stddev, unsi
         mat[idx] = curand_normal(&state) * stddev + mean;
     }
 }
-
-
-using namespace std;
 
 void fill(float* mat, uint m, uint n, float mean = 0.0f, float stddev = 1.0f) {
     float* d_mat;
@@ -48,11 +48,11 @@ void fill(float* mat, uint m, uint n, float mean = 0.0f, float stddev = 1.0f) {
     uint threadsPerBlockDim = 16;
     // The grid will be sized to cover the entire matrix, rows (m)
     // in the y dimension and columns (n) in the x dimension.
-    dim3 gridDim { 
-        static_cast<uint>(ceil(n / threadsPerBlockDim) + 1), 
+    dim3 gridDim {
+        static_cast<uint>(ceil(n / threadsPerBlockDim) + 1),
         static_cast<uint>(ceil(m / threadsPerBlockDim) + 1)};
     dim3 blockDim { threadsPerBlockDim, threadsPerBlockDim };
-    printf("Grid dimensions: %d x %d, Block dimensions: %d x %d\n", 
+    printf("Grid dimensions: %d x %d, Block dimensions: %d x %d\n",
            gridDim.x, gridDim.y, blockDim.x, blockDim.y);
 
     RectangularCheckStrategy strategy(m, n);
@@ -73,10 +73,10 @@ void fill(float* mat, uint m, uint n, float mean = 0.0f, float stddev = 1.0f) {
 
     // Launch kernel
     fillMatrixKernel<<<gridDim, blockDim>>>(
-        d_mat, 
+        d_mat,
         d_strategy,
-        mean, 
-        stddev, 
+        mean,
+        stddev,
         time(nullptr));
 
     // Copy result back to host
@@ -89,31 +89,4 @@ void fill(float* mat, uint m, uint n, float mean = 0.0f, float stddev = 1.0f) {
 
     // Cleanup
     cudaFree(d_mat);
-}
-
-
-int main(int argc, char* argv[]) {
-    // Default values for matrix dimensions
-    int M = 10;
-    int N = 15;
-
-    // Parse command line arguments if provided
-    if (argc > 1) M = atoi(argv[1]);
-    if (argc > 2) N = atoi(argv[2]);
-
-    printf("Creating matrix of size %d x %d\n", M, N);
-    float* matrix = new float[M * N];
-
-    fill(matrix, M, N);  // Using default mean=0.0 and stddev=1.0
-
-    // Print the matrix
-    for (int i = 0; i < M; i++) {
-        for (int j = 0; j < N; j++) {
-            printf("%8.4f", matrix[i * N + j]);
-        }
-        printf("\n");
-    }
-
-    delete[] matrix;
-    return 0;
 }

--- a/src/mat_gen.cu
+++ b/src/mat_gen.cu
@@ -4,10 +4,9 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 //
 // Author: Marco Massenzio (marco@alertavert.com)
-
-#include <cuda_runtime.h>
 #include <curand.h>
 #include <curand_kernel.h>
+
 #include <iostream>
 #include <memory>
 
@@ -16,77 +15,76 @@
 
 using namespace std;
 
-__global__
-void fillMatrixKernel(float* mat, void* strategy, float mean, float stddev, unsigned long seed) {
-
-    // Here we lose the flexibility of polymorphic behavior,
-    // as we need to know in advance the type of strategy.
-    // However, in kernel functions, we must know in advance the
-    // arrangement of data anyway.
-    SizeCheck checker { strategy, BoundaryType::Rectangular };
-    if (checker()) {
-        auto idx = checker.idx();
-        curandState state;
-        curand_init(seed, idx, 0, &state);
-        mat[idx] = curand_normal(&state) * stddev + mean;
-    }
+__global__ void fillMatrixKernel(float* mat, void* strategy, float mean,
+                                 float stddev, unsigned long seed) {
+  // Here we lose the flexibility of polymorphic behavior,
+  // as we need to know in advance the type of strategy.
+  // However, in kernel functions, we must know in advance the
+  // arrangement of data anyway.
+  SizeCheck checker{strategy, BoundaryType::Rectangular};
+  if (checker()) {
+    auto idx = checker.idx();
+    curandState state;
+    curand_init(seed, idx, 0, &state);
+    mat[idx] = curand_normal(&state) * stddev + mean;
+  }
 }
 
-void fill(float* mat, uint m, uint n, float mean = 0.0f, float stddev = 1.0f) {
-    float* d_mat;
-    size_t size = m * n * sizeof(float);
+void fill(float* mat, uint m, uint n, float mean, float stddev) {
+  float* d_mat;
+  size_t size = m * n * sizeof(float);
 
-    // Allocate device memory
-    cudaError_t err = cudaMalloc(&d_mat, size);
-    if (err != cudaSuccess) {
-        cerr << "Failed to allocate device memory: " << cudaGetErrorString(err) << endl;
-        return;
-    }
+  // Allocate device memory
+  cudaError_t err = cudaMalloc(&d_mat, size);
+  if (err != cudaSuccess) {
+    cerr << "Failed to allocate device memory: " << cudaGetErrorString(err)
+         << endl;
+    return;
+  }
 
-    // Configure kernel launch parameters
-    // Each block will handle 16x16 threads
-    uint threadsPerBlockDim = 16;
-    // The grid will be sized to cover the entire matrix, rows (m)
-    // in the y dimension and columns (n) in the x dimension.
-    dim3 gridDim {
-        static_cast<uint>(ceil(n / threadsPerBlockDim) + 1),
-        static_cast<uint>(ceil(m / threadsPerBlockDim) + 1)};
-    dim3 blockDim { threadsPerBlockDim, threadsPerBlockDim };
-    printf("Grid dimensions: %d x %d, Block dimensions: %d x %d\n",
-           gridDim.x, gridDim.y, blockDim.x, blockDim.y);
+  // Configure kernel launch parameters
+  // Each block will handle 16x16 threads
+  uint threadsPerBlockDim = 16;
+  // The grid will be sized to cover the entire matrix, rows (m)
+  // in the y dimension and columns (n) in the x dimension.
+  dim3 gridDim{static_cast<uint>(ceil(n / threadsPerBlockDim) + 1),
+               static_cast<uint>(ceil(m / threadsPerBlockDim) + 1)};
+  dim3 blockDim{threadsPerBlockDim, threadsPerBlockDim};
+  printf("Grid dimensions: %d x %d, Block dimensions: %d x %d\n", gridDim.x,
+         gridDim.y, blockDim.x, blockDim.y);
 
-    RectangularCheckStrategy strategy(m, n);
-    RectangularCheckStrategy* d_strategy;
-    err = cudaMalloc(&d_strategy, sizeof(RectangularCheckStrategy));
-    if (err != cudaSuccess) {
-        cerr << "Failed to allocate device memory for strategy: " << cudaGetErrorString(err) << endl;
-        cudaFree(d_mat);
-        return;
-    }
-    err = cudaMemcpy(d_strategy, &strategy, sizeof(RectangularCheckStrategy), cudaMemcpyHostToDevice);
-    if (err != cudaSuccess) {
-        cerr << "Failed to copy strategy to device: " << cudaGetErrorString(err) << endl;
-        cudaFree(d_mat);
-        cudaFree(d_strategy);
-        return;
-    }
-
-    // Launch kernel
-    fillMatrixKernel<<<gridDim, blockDim>>>(
-        d_mat,
-        d_strategy,
-        mean,
-        stddev,
-        time(nullptr));
-
-    // Copy result back to host
-    err = cudaMemcpy(mat, d_mat, size, cudaMemcpyDeviceToHost);
-    if (err != cudaSuccess) {
-        cerr << "Failed to copy data from device: " << cudaGetErrorString(err) << endl;
-        cudaFree(d_mat);
-        return;
-    }
-
-    // Cleanup
+  RectangularCheckStrategy strategy(m, n);
+  RectangularCheckStrategy* d_strategy;
+  err = cudaMalloc(&d_strategy, sizeof(RectangularCheckStrategy));
+  if (err != cudaSuccess) {
+    cerr << "Failed to allocate device memory for strategy: "
+         << cudaGetErrorString(err) << endl;
     cudaFree(d_mat);
+    return;
+  }
+  err = cudaMemcpy(d_strategy, &strategy, sizeof(RectangularCheckStrategy),
+                   cudaMemcpyHostToDevice);
+  if (err != cudaSuccess) {
+    cerr << "Failed to copy strategy to device: " << cudaGetErrorString(err)
+         << endl;
+    cudaFree(d_mat);
+    cudaFree(d_strategy);
+    return;
+  }
+
+  // Launch kernel
+  fillMatrixKernel<<<gridDim, blockDim>>>(d_mat, d_strategy, mean, stddev,
+                                          time(nullptr));
+
+  // Copy result back to host
+  err = cudaMemcpy(mat, d_mat, size, cudaMemcpyDeviceToHost);
+  if (err != cudaSuccess) {
+    cerr << "Failed to copy data from device: " << cudaGetErrorString(err)
+         << endl;
+    cudaFree(d_mat);
+    return;
+  }
+
+  // Cleanup
+  cudaFree(d_mat);
 }


### PR DESCRIPTION
The `fillMatrix()` functionality is now available for other modules to use:

    - Refactor CUDA build configuration 
    - add `fillmatrix.h` header
    - tested changes build & run
    - added a simple 'demo' binary to run examples.